### PR TITLE
Add support of arbitrary CCM and CFA in finishing.

### DIFF
--- a/src/Burst.h
+++ b/src/Burst.h
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <vector>
-#include <Halide.h>
 
 class Burst {
 public:
@@ -22,11 +21,15 @@ public:
 
     int GetHeight() const { return Raws.empty() ? -1 : Raws[0].GetHeight(); }
 
-    int GetBlackLevel() const { return Raws.empty() ? -1 : Raws[0].GetBlackLevel(); }
+    int GetBlackLevel() const { return Raws.empty() ? -1 : Raws[0].GetScalarBlackLevel(); }
 
     int GetWhiteLevel() const { return Raws.empty() ? -1 : Raws[0].GetWhiteLevel(); }
 
     WhiteBalance GetWhiteBalance() const { return Raws.empty() ? WhiteBalance{-1, -1, -1, -1} : Raws[0].GetWhiteBalance(); }
+
+    CfaPattern GetCfaPattern() const { return Raws.empty() ? CfaPattern::CFA_UNKNOWN : Raws[0].GetCfaPattern(); }
+    
+    Halide::Runtime::Buffer<float> GetColorCorrectionMatrix() const { return Raws.empty() ? Halide::Runtime::Buffer<float>() : Raws[0].GetColorCorrectionMatrix(); }
 
     Halide::Runtime::Buffer<uint16_t> ToBuffer() const;
 

--- a/src/InputSource.cpp
+++ b/src/InputSource.cpp
@@ -1,4 +1,8 @@
 #include "InputSource.h"
+
+#include <algorithm>
+#include <unordered_map>
+
 #include "LibRaw2DngConverter.h"
 
 RawImage::RawImage(const std::string &path)
@@ -46,7 +50,83 @@ void RawImage::CopyToBuffer(Halide::Runtime::Buffer<uint16_t> &buffer) const {
 
 void RawImage::WriteDng(const std::string &output_path, const Halide::Runtime::Buffer<uint16_t> &buffer) const
 {
-    LibRaw2DngConverter converter(*RawProcessor);
+    LibRaw2DngConverter converter(*this);
     converter.SetBuffer(buffer);
     converter.Write(output_path);
 }
+
+std::array<float, 4> RawImage::GetBlackLevel() const {
+    // See https://www.libraw.org/node/2471
+    const auto raw_color = RawProcessor->imgdata.color;
+    const auto base_black_level = static_cast<float>(raw_color.black);
+
+    std::array<float, 4> black_level = {
+        base_black_level + static_cast<float>(raw_color.cblack[0]),
+        base_black_level + static_cast<float>(raw_color.cblack[1]),
+        base_black_level + static_cast<float>(raw_color.cblack[2]),
+        base_black_level + static_cast<float>(raw_color.cblack[3])
+    };
+
+    if (raw_color.cblack[4] == 2 && raw_color.cblack[5] == 2) {
+        for (int x = 0; x < raw_color.cblack[4]; ++x) {
+            for (int y = 0; y < raw_color.cblack[5]; ++y) {
+                const auto index = y * 2 + x;
+                black_level[index] = raw_color.cblack[6 + index];
+            }
+        }
+    }
+
+    return black_level;
+}
+
+int RawImage::GetScalarBlackLevel() const {
+    const auto black_level = GetBlackLevel();
+    return static_cast<int>(*std::min_element(black_level.begin(), black_level.end()));
+}
+
+std::string RawImage::GetCfaPatternString() const {
+    static const std::unordered_map<char, char> CDESC_TO_CFA = {
+        {'R', 0},
+        {'G', 1},
+        {'B', 2},
+        {'r', 0},
+        {'g', 1},
+        {'b', 2}
+    };
+    const auto &cdesc = RawProcessor->imgdata.idata.cdesc;
+    return {
+        CDESC_TO_CFA.at(cdesc[RawProcessor->COLOR(0, 0)]),
+        CDESC_TO_CFA.at(cdesc[RawProcessor->COLOR(0, 1)]),
+        CDESC_TO_CFA.at(cdesc[RawProcessor->COLOR(1, 0)]),
+        CDESC_TO_CFA.at(cdesc[RawProcessor->COLOR(1, 1)])
+    };
+}
+
+CfaPattern RawImage::GetCfaPattern() const {
+    const auto cfa_pattern = GetCfaPatternString();
+    if (cfa_pattern == std::string{0, 1, 1, 2}) {
+        return CfaPattern::CFA_RGGB;
+    } else if (cfa_pattern == std::string{1, 0, 2, 1}) {
+        return CfaPattern::CFA_GRBG;
+    } else if (cfa_pattern == std::string{2, 1, 1, 0}) {
+        return CfaPattern::CFA_BGGR;
+    } else if (cfa_pattern == std::string{1, 2, 0, 1}) {
+        return CfaPattern::CFA_GBRG;
+    }
+    throw std::invalid_argument("Unsupported CFA pattern: " + cfa_pattern);
+    return CfaPattern::CFA_UNKNOWN;
+}
+
+Halide::Runtime::Buffer<float> RawImage::GetColorCorrectionMatrix() const {
+    const auto raw_color = RawProcessor->imgdata.color;
+    Halide::Runtime::Buffer<float> ccm(3, 3);
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            std::cerr << "raw_color.rgb_cam[i][j]: " << raw_color.rgb_cam[i][j] << std::endl;
+            ccm(i, j) = raw_color.rgb_cam[j][i];
+        }
+    }
+    return ccm;
+}
+
+

--- a/src/InputSource.cpp
+++ b/src/InputSource.cpp
@@ -122,7 +122,6 @@ Halide::Runtime::Buffer<float> RawImage::GetColorCorrectionMatrix() const {
     Halide::Runtime::Buffer<float> ccm(3, 3);
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {
-            std::cerr << "raw_color.rgb_cam[i][j]: " << raw_color.rgb_cam[i][j] << std::endl;
             ccm(i, j) = raw_color.rgb_cam[j][i];
         }
     }

--- a/src/InputSource.h
+++ b/src/InputSource.h
@@ -17,17 +17,25 @@ public:
 
     int GetHeight() const { return RawProcessor->imgdata.rawdata.sizes.height; }
 
-    int GetBlackLevel() const { return RawProcessor->imgdata.color.black; }
+    int GetScalarBlackLevel() const;
+
+    std::array<float, 4> GetBlackLevel() const;
 
     int GetWhiteLevel() const { return RawProcessor->imgdata.color.maximum; }
 
     WhiteBalance GetWhiteBalance() const;
+
+    std::string GetCfaPatternString() const;
+    CfaPattern GetCfaPattern() const;
+
+    Halide::Runtime::Buffer<float> GetColorCorrectionMatrix() const;
 
     void CopyToBuffer(Halide::Runtime::Buffer<uint16_t>& buffer) const;
 
     // Writes current RawImage as DNG. If buffer was provided, then use it instead of internal buffer.
     void WriteDng(const std::string& path, const Halide::Runtime::Buffer<uint16_t>& buffer = {}) const;
 
+    std::shared_ptr<LibRaw> GetRawProcessor() const { return RawProcessor; }
 private:
     std::string Path;
     std::shared_ptr<LibRaw> RawProcessor;

--- a/src/LibRaw2DngConverter.h
+++ b/src/LibRaw2DngConverter.h
@@ -5,13 +5,14 @@
 #include <tiffio.hxx>
 
 #include <HalideBuffer.h>
-#include <libraw/libraw.h>
+
+class RawImage;
 
 class LibRaw2DngConverter {
     using TiffPtr = std::shared_ptr<TIFF>;
     TiffPtr SetTiffFields(TiffPtr tiff_ptr);
 public:
-    explicit LibRaw2DngConverter(const LibRaw& raw);
+    explicit LibRaw2DngConverter(const RawImage& raw);
 
     void SetBuffer(const Halide::Runtime::Buffer<uint16_t>& buffer) const;
 
@@ -19,6 +20,6 @@ public:
 
 private:
     std::ostringstream OutputStream;
-    const LibRaw& Raw;
+    const RawImage& Raw;
     std::shared_ptr<TIFF> Tiff;
 };

--- a/src/finish.h
+++ b/src/finish.h
@@ -6,7 +6,7 @@
 template <class T = float>
 struct TypedWhiteBalance {
     template<class TT>
-    TypedWhiteBalance(const TypedWhiteBalance<TT>& other)
+    explicit TypedWhiteBalance(const TypedWhiteBalance<TT>& other)
         : r(other.r)
         , g0(other.g0)
         , g1(other.g1)
@@ -25,6 +25,7 @@ struct TypedWhiteBalance {
     T g1;
     T b;
 };
+
 using WhiteBalance = TypedWhiteBalance<float>;
 using CompiletimeWhiteBalance = TypedWhiteBalance<Halide::Expr>;
 
@@ -34,6 +35,14 @@ typedef uint16_t WhitePoint;
 typedef float Compression;
 typedef float Gain;
 
+enum class CfaPattern : int {
+    CFA_UNKNOWN = 0,
+    CFA_RGGB = 1,
+    CFA_GRBG = 2,
+    CFA_BGGR = 3,
+    CFA_GBRG = 4
+};
+
 /*
  * finish -- Applies a series of standard local and global image processing
  * operations to an input mosaicked image, producing a pleasant color output.
@@ -42,7 +51,7 @@ typedef float Gain;
  * and gain amounts. This produces natural-looking brightened shadows, without
  * blowing out highlights. The output values are 8-bit.
  */
-Halide::Func finish(Halide::Func input, int width, int height, const BlackPoint bp, const WhitePoint wp, const WhiteBalance &wb, const Compression c, const Gain g);
-Halide::Func finish(Halide::Func input, Halide::Expr width, Halide::Expr height, const Halide::Expr bp, const Halide::Expr wp, const CompiletimeWhiteBalance &wb, const Halide::Expr c, const Halide::Expr g);
+Halide::Func finish(Halide::Func input, int width, int height, BlackPoint bp, WhitePoint wp, const WhiteBalance &wb, CfaPattern cfa, Halide::Func ccm, Compression c, Gain g);
+Halide::Func finish(Halide::Func input, Halide::Expr width, Halide::Expr height, Halide::Expr bp, Halide::Expr wp, const CompiletimeWhiteBalance &wb, Halide::Expr cfa_pattern, Halide::Func ccm, Halide::Expr c, Halide::Expr g);
 
 #endif

--- a/src/hdrplus_pipeline_generator.cpp
+++ b/src/hdrplus_pipeline_generator.cpp
@@ -16,6 +16,9 @@ namespace {
         Input<float> white_balance_g0{"white_balance_g0"};
         Input<float> white_balance_g1{"white_balance_g1"};
         Input<float> white_balance_b{"white_balance_b"};
+        Input<int> cfa_pattern{"cfa_pattern"};
+        Input<Halide::Buffer<float>> ccm{"ccm", 2}; // ccm - color correction matrix
+        
         Input<float> compression{"compression"};
         Input<float> gain{"gain"};
 
@@ -27,7 +30,7 @@ namespace {
             Func alignment = align(inputs, inputs.width(), inputs.height());
             Func merged = merge(inputs, inputs.width(), inputs.height(), inputs.dim(2).extent(), alignment);
             CompiletimeWhiteBalance wb{ white_balance_r, white_balance_g0, white_balance_g1, white_balance_b };
-            Func finished = finish(merged, inputs.width(), inputs.height(), black_point, white_point, wb, compression, gain);
+            Func finished = finish(merged, inputs.width(), inputs.height(), black_point, white_point, wb, cfa_pattern, ccm, compression, gain);
             output = finished;
             // Schedule handled inside included functions
         }


### PR DESCRIPTION
Solves #39 and maybe #48.

CCM stands for the color correction matrix, which is used in `srgb` [function](https://github.com/timothybrooks/hdr-plus/pull/54/files#diff-238124976a9decb48598fb04b7ffd0f8R523) in finishing. CCM depends on the sensor model and shouldn't be hardcoded. Wrong CCM results in incorrect output color. Now color should be Okay on most of input RAWs.

CFA stands for [Color Filter Array](https://en.wikipedia.org/wiki/Bayer_filter) or Bayer Filter. Most of the sensors use the RGGB pattern, but it may be shifted by one pixel in horizontal and/or vertical direction. I added `shift_bayer_to_rggb` [function](https://github.com/timothybrooks/hdr-plus/pull/54/files#diff-238124976a9decb48598fb04b7ffd0f8R648) on the start of `finish`, which shifts input raw image depending on the RAW CFA pattern.

It also fixes black level for DNGs input from the hdrplus dataset - I reused black level calculation function from `LibRaw2DngConverter`.

Tested on hdrplus data and Timothy's RAWs.