### PR TITLE
Add missing include header

### DIFF
--- a/src/InputSource.h
+++ b/src/InputSource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <string>
 
 #include <libraw/libraw.h>


### PR DESCRIPTION
Fix compilation error on nixpkgs (NixOS/nixpkgs#146898)

```
[ 42%] Building CXX object CMakeFiles/hdrplus.dir/src/InputSource.cpp.o
/tmp/nix-build-hdr-plus-unstable-2020-10-29.drv-0/source/src/InputSource.cpp:58:32: error: implicit instantiation of undefined template 'std::__1::array<float, 4>'
std::array<float, 4> RawImage::GetBlackLevel() const {
                               ^
/nix/store/78a4mwr6n6jfnjs6k26jbm56xyaarihj-libcxx-7.1.0-dev/include/c++/v1/__tuple:223:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
/tmp/nix-build-hdr-plus-unstable-2020-10-29.drv-0/source/src/InputSource.cpp:63:26: error: implicit instantiation of undefined template 'std::__1::array<float, 4>'
    std::array<float, 4> black_level = {
                         ^
/nix/store/78a4mwr6n6jfnjs6k26jbm56xyaarihj-libcxx-7.1.0-dev/include/c++/v1/__tuple:223:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
2 errors generated.
make[2]: *** [CMakeFiles/hdrplus.dir/build.make:90: CMakeFiles/hdrplus.dir/src/InputSource.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:102: CMakeFiles/hdrplus.dir/all] Error 2
```